### PR TITLE
Update Schedule of future disclosures

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 When I report security issues vendors generally get 90 days to fix them. Once that deadline is over I disclose my research. If you are interested in reading the disclosures, you can subscribe to the RSS feed of this blog. Alternatively, you could also check my blog on the scheduled disclosure dates:
 
 - 2023-01-09: TouchEn nxKey: The keylogging anti-keylogger solution ([번역 글]())
-- 2023-01-23 (January 23rd)
+- 2023-01-25 (January 25th) **Edit**: Disclosure date was moved due to Korean holidays.
 - 2023-02-06 (February 6th)
 - 2023-03-06 (March 6th)
 


### PR DESCRIPTION
See in https://palant.info/2023/01/02/south-koreas-online-security-dead-end/

공개일자가 설날로 인해 변경되었습니다.