### PR TITLE
`README.md` 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 # KoreaSecurityApps
 
-이 리포는 [Wladimir Palant](https://palant.info/about/)라는 Adblock Plus개발자가 본인의 보안관련 블로그에 한국 금융권에서 사용되는 보안 소프투웨어의 취약점을 공개한 글의 번역 글의 모음이다. 
+이 저장소는 Adblock Plus로 유명한 독일의 개발자 [블라디미르 팔란트(Wladimir Palant)](https://palant.info/about/)가 자신의 블로그에 공개한, 한국 금융권에서 사용자에게 설치를 강요하는 여러 “보안 소프트웨어”의 각종 보안 취약점에 대한 내용을 번역한 모음집이다.
 
-원저자가 [South Korea's Online Security Dead End](https://palant.info/2023/01/02/south-koreas-online-security-dead-end/)글에 작성한 앞으로 공개하기로 한 글의 목록은 다음과 같다.
+원저자는 첫번째 글([South Korea's Online Security Dead End](https://palant.info/2023/01/02/south-koreas-online-security-dead-end/)) 말미에서 앞으로 다음과 같은 내용을 더 공개하기로 하였다.
 
-## Schedule of future disclosures
-When I report security issues vendors generally get 90 days to fix them. Once that deadline is over I disclose my research. If you are interested in reading the disclosures, you can subscribe to the RSS feed of this blog. Alternatively, you could also check my blog on the scheduled disclosure dates:
+> ## 향후 공개 일정
+>
+> 보안 문제를 보고할 경우, 업체에서는 일반적으로 90일 동안 그 문제를 수정한다. 마감일이 지나고 나면, 나는 그 내용을 공개할 것이다. 만약 공개되는 내용에 관심이 있다면, 이 블로그의 RSS 피드를 구독하기 바란다. 아니면 다음과 같이 예정된 공개 날짜에 내 블로그를 확인하면 된다.
+>
+> - 2023-01-09: [TouchEn nxKey: 키로깅 방지를 위해 키로깅하는 솔루션](https://github.com/alanleedev/KoreaSecurityApps/blob/main/01_touchen_nxkey.md)
+> - 2023-01-25 **수정**: 한국의 명절 때문에 공개 날짜를 미루었다.
+> - 2023-02-06
+> - 2023-03-06
 
-- 2023-01-09: [TouchEn nxKey: The keylogging anti-keylogger solution](https://palant.info/2023/01/09/touchen-nxkey-the-keylogging-anti-keylogger-solution/) ([번역 글](https://github.com/alanleedev/KoreaSecurityApps/blob/main/01_touchen_nxkey.md))
-- 2023-01-25 (January 25th) **Edit**: Disclosure date was moved due to Korean holidays.
-- 2023-02-06 (February 6th)
-- 2023-03-06 (March 6th)
-
-이 시리즈의 도입글 [South Korea’s online security dead end](https://palant.info/2023/01/02/south-koreas-online-security-dead-end/) 에 대한 김우진 님의 번역글은 [여기](https://www.woojinkim.org/wiki/spaces/me/pages/733085820/South+Korea+s+online+security+dead+end)서 볼 수 있다.
+이 시리즈의 도입글 [South Korea’s online security dead end](https://palant.info/2023/01/02/south-koreas-online-security-dead-end/)에 대한 김우진 님의 번역글은 [여기](https://www.woojinkim.org/wiki/spaces/me/pages/733085820)서 볼 수 있다.
 
 ---
+
 ## 번역 및 내용 수정에 도움을 주신 분들:
+
 - [@MerHS](https://github.com/MerHS)
 - [@DaeHyeoNi](https://github.com/DaeHyeoNi)
 - [@MerHS](https://github.com/MerHS)
@@ -27,22 +30,25 @@ When I report security issues vendors generally get 90 days to fix them. Once th
 ## 번역에 참여하는 분을 위한 정보
 
 ### 번역의 목표
- - 한국어로 읽을 때 크게 어색하지 않고 비교적 쉽게 읽고 이해할 수 있게 번역하며, 무엇보다 정확한 정보의 전달에 목표를 둔다.
+
+- 한국어로 읽을 때 크게 어색하지 않고 비교적 쉽게 읽고 이해할 수 있게 번역하며, 무엇보다 정확한 정보의 전달에 목표를 둔다.
 
 ### 번역 가이드
- - 완벽한 번역을 목표로 하지 않는다 (봉사자의 시간과 정신 건강을 위해)
- - 우선적으로 오타 및 비문을 고치고 필요에 따라 어색한 직역체 대신 좀 더 이사하기 쉬운 의역체를 사용한다.
- - 번역 상 오류나 읽기 어려운 부분이 아닌 단순 스타일에 대한 수정은 어느 정도 완성도를 높인 후 선택적으로 한다.(생략 가능)
+
+- 완벽한 번역을 목표로 하지 않는다. (봉사자의 시간과 정신 건강을 위해)
+- 우선적으로 오타 및 비문을 고치고, 필요에 따라 어색한 직역체 대신 좀 더 이해하기 쉬운 의역체를 사용한다.
+- 번역 상 오류나 읽기 어려운 부분이 아닌 단순 스타일에 대한 수정은 어느 정도 완성도를 높인 후 선택적으로 한다. (생략 가능)
 
 ### 번역 방법
- - 일단 초벌 번역된 글이 GitHub에 올린다.
- - 해 당 글 내의 제목별로 issue를 만들어서 등록한다.
- - 1차 검토자가 해당 issue를 자신에게 할당한 후 번역을 수정하는 작업에 들어간다. 결과물은 PR로 올린다.
- - PR 2차 검토자가 승인하는 것으로 하고, 협의가 필요한 것 PR을 통해서 서로 조율한 후 승인 한다.
+
+- 일단 초벌 번역된 글을 GitHub에 올린다.
+- 해당 글의 소제목별로 issue를 만들어서 등록한다.
+- 1차 검토자가 해당 issue를 자신에게 할당한 후, 번역을 수정하는 작업에 들어간다.
+- 수정된 결과물은 PR로 올린다.
+- PR 2차 검토자가 승인하는 것으로 하고, 협의가 필요한 것 PR을 통해서 서로 조율한 후 승인한다.
 
 ### 번역 상태 표기
+
 - 일단 독자를 위해 글 상단에 번역 상태를 표시한다. 상태는 아래와 같다:
-  - 초벌 번역, 1차 검토/ 수정 중, 2차 검토/ 수정 중, .... , 번역 완료
-  - 번역 완료는 번역 및 검토에 참여한 사람들과 합의해서 정한다
-
-
+  - 초벌 번역, 1차 검토/수정 중, 2차 검토/수정 중, …, 번역 완료
+  - 번역 완료는 번역 및 검토에 참여한 사람들과 합의해서 정한다.


### PR DESCRIPTION
이 저장소의 대문인 `README.md`를 수정해 보았습니다.

- 원작자 글의 향후 공개 내용이 영어 원문으로 되어 있는 것을 한국어로 번역
- 번역에 맞추어, 첫번째 글의 링크 주소를 원문에서 이 저장소의 번역문으로 변경
- 소제목 아래는 한 줄 띄우는 것으로 스타일 통일
- 기타 내용 다듬기 등